### PR TITLE
Enable PM2 to automatically restart Open Terms Archive applications after a reboot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All changes that impact users of this module are documented in this file, in the [Common Changelog](https://common-changelog.org) format with some additional specifications defined in the CONTRIBUTING file. This codebase adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased [minor]
+
+> Development of this release was supported by the [French Ministry for Foreign Affairs](https://www.diplomatie.gouv.fr/fr/politique-etrangere-de-la-france/diplomatie-numerique/) through its ministerial [State Startups incubator](https://beta.gouv.fr/startups/open-terms-archive.html) under the aegis of the Ambassador for Digital Affairs.
+
+### Added
+
+- Enable PM2 to automatically restart Open Terms Archive applications after a reboot
+
 ## 2.0.2 - 2024-06-12
 
 _Full changeset and discussions: [#46](https://github.com/OpenTermsArchive/deployment/pull/46)._

--- a/roles/pm2/manage/tasks/main.yml
+++ b/roles/pm2/manage/tasks/main.yml
@@ -23,6 +23,13 @@
     - restart
     - start
 
+- name: Generate and enable PM2 startup script
+  ansible.builtin.command:
+    cmd: sudo env PATH=$PATH:/usr/bin pm2 startup systemd -u {{ ansible_user }} --hp /home/{{ ansible_user }}
+  tags:
+    - restart
+    - start
+
 - name: Start Open Terms Archive applications
   ansible.builtin.command:
     cmd: pm2 startOrRestart pm2.config.cjs
@@ -32,3 +39,12 @@
   tags:
     - restart
     - start
+
+- name: Save PM2 process list for auto-restart
+  ansible.builtin.command:
+    cmd: pm2 save
+    chdir: /home/{{ ansible_user }}/{{ ota_directory }}
+  tags:
+    - restart
+    - start
+    - stop

--- a/roles/pm2/manage/tasks/main.yml
+++ b/roles/pm2/manage/tasks/main.yml
@@ -25,7 +25,7 @@
 
 - name: Generate and enable PM2 startup script
   ansible.builtin.command:
-    cmd: sudo env PATH=$PATH:/usr/bin pm2 startup systemd -u {{ ansible_user }} --hp /home/{{ ansible_user }}
+    cmd: sudo env PATH=$PATH:/usr/bin pm2 startup systemd --user {{ ansible_user }} --hp /home/{{ ansible_user }}
   tags:
     - restart
     - start


### PR DESCRIPTION
Tested on the experimentation server.